### PR TITLE
fix for %p placeholder

### DIFF
--- a/jdatetime/__init__.py
+++ b/jdatetime/__init__.py
@@ -573,7 +573,7 @@ class date(object):
             format = format.replace("%-M", '0')
 
         try:
-            if self.hour > 12:
+            if self.hour >= 12:
                 format = format.replace("%p", self.j_ampm['PM'])
             else:
                 format = format.replace("%p", self.j_ampm['AM'])


### PR DESCRIPTION
When hour == 12, '%p' should print 'PM', not 'AM'.